### PR TITLE
Sane regexp support for search

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -190,3 +190,7 @@ set cursorline
 if v:version >= 703
     set colorcolumn=80
 endif
+
+"fix Vim's horribly broken default regex 'handling'
+nnoremap / /\v
+vnoremap / /\v


### PR DESCRIPTION
Allow crazy stuff like "/function(" to search for "function(".
